### PR TITLE
Simple AMD Loader

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+          },
+          {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Current File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+              "${fileBasenameNoExtension}",
+              "--config",
+              "jest.config.js"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+          }
+    ]
+}

--- a/__tests__/modules/amdModule.tests.ts
+++ b/__tests__/modules/amdModule.tests.ts
@@ -1,0 +1,64 @@
+import * as AmdModule from "../../src//modules/amdModule";
+import fs from "fs";
+import path, { dirname } from "path";
+import util from "util";
+
+const readFile = util.promisify(fs.readFile);
+
+describe(`AMD Module Tests`, () => {
+    const testDir = ((): string =>  {
+        if (__dirname.match(/modules$/)) {
+            return path.resolve(__dirname, "../testData");
+        } else if (__dirname.match(/amd_loader$/)) {
+            return path.resolve(__dirname, "__tests__/testData");
+        } else {
+            return __dirname;
+        }
+    })();
+
+    beforeEach(() => {
+        AmdModule.clearModuleCache();
+    });
+
+    it(`Test that test file exists`, async () => {
+        const moduleName = `simpleModules/moduleA`;
+        const filePath = path.resolve(testDir, moduleName + ".js");
+        const exists = fs.existsSync(filePath);
+        expect(exists).toBeTruthy();
+    });
+
+    it(`Verify that normal Define Registers a module`, () => {
+        const moduleName = `simpleModules/moduleA`;
+        expect(AmdModule.ModuleCache[moduleName]).toBeFalsy();
+
+        // tslint:disable-next-line: no-string-literal
+        global["_modulePath"] = "abc";
+        AmdModule.defineModule(moduleName, [], () => "fsfsd");
+        expect(AmdModule.ModuleCache[moduleName]).toBeTruthy();
+    });
+
+    it(`Verify that global define exists`, () => {
+        const defineType = typeof define;
+        expect(defineType).toBe("function");
+    });
+
+    it(`Get Simple Module`, async () => {
+        const moduleName = `simpleModules/moduleA`;
+        const expectedModulePath = path.resolve(testDir, moduleName + ".js");
+
+        AmdModule.updateModuleGetter("getModulePath", (moduleName) => {
+            return path.resolve(testDir, moduleName + ".js");
+        });
+
+        AmdModule.updateModuleGetter("getModuleContents", (modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        const moduleA = await AmdModule.requireModule(moduleName);
+        expect(moduleA).toBeTruthy();
+        expect(moduleA.path).toBe(expectedModulePath);
+        expect(moduleA.exports.moduleName).toBe("moduleA");
+    });
+
+});
+

--- a/__tests__/modules/amdModule.tests.ts
+++ b/__tests__/modules/amdModule.tests.ts
@@ -31,14 +31,13 @@ describe(`AMD Module Tests`, () => {
         const moduleName = `simpleModules/moduleA`;
         expect(AmdModule.ModuleCache[moduleName]).toBeFalsy();
 
-        // tslint:disable-next-line: no-string-literal
-        global["_modulePath"] = "abc";
         AmdModule.defineModule(moduleName, [], () => "fsfsd");
         expect(AmdModule.ModuleCache[moduleName]).toBeTruthy();
     });
 
     it(`Verify that global define exists`, () => {
-        const defineType = typeof define;
+        // tslint:disable-next-line: no-string-literal
+        const defineType = typeof global["define"];
         expect(defineType).toBe("function");
     });
 

--- a/__tests__/testData/simpleModules/moduleA.js
+++ b/__tests__/testData/simpleModules/moduleA.js
@@ -1,0 +1,6 @@
+
+define("simpleModules/moduleA", [], function() {
+    return {
+        moduleName: "moduleA"
+    }
+});

--- a/src/dummy.ts
+++ b/src/dummy.ts
@@ -1,1 +1,0 @@
-// Dummy file to make the build pass

--- a/src/modules/amdModule.ts
+++ b/src/modules/amdModule.ts
@@ -1,0 +1,218 @@
+
+import events from "events";
+import vm from "vm";
+
+export type AmdModuleListener = (amdModule: IAmdModule) => void;
+export type EventDisconnect = () => void;
+
+export interface IAmdModule {
+    name: string;
+    path: string;
+    dependencies: string[];
+    factory: Function;
+    loaded: boolean;
+    exports: any;
+
+    on(evtId: "defined" | "ready", callback: AmdModuleListener): EventDisconnect;
+    on(evtId: "error", callback: (e: Error) => void ): EventDisconnect;
+
+    emit(evtId: "defined" | "ready"): boolean;
+
+    load(): Promise<this>;
+}
+
+export interface IModuleGetter {
+    getModulePath: (moduleName: string) => string;
+
+    getModuleContents: (modulePath: string) => Promise<string>;
+}
+
+export let ModuleCache: {[key: string]: IAmdModule} = {};
+
+export function clearModuleCache(): {[key: string]: IAmdModule} {
+    ModuleCache = {};
+    return ModuleCache;
+}
+
+let ModuleGetter: IModuleGetter = {
+    getModulePath: (moduleName: string) => moduleName,
+
+    getModuleContents: (modulePath: string) => {
+        return Promise.resolve(`throw new error('default reader');`);
+    },
+};
+
+
+export function requireModule(moduleId: string): Promise<IAmdModule> {
+    return new Promise<IAmdModule>((resolve, reject) => {
+
+        let amdModule = ModuleCache[moduleId];
+        if (!amdModule) {
+            amdModule = new AmdModule(moduleId);
+            ModuleCache[moduleId] = amdModule;
+        }
+
+        const disconnectOnReady = amdModule.on("ready", (loadedModule) => {
+            disconnectOnReady();
+            resolve(loadedModule);
+        });
+
+        const disconnectOnError = amdModule.on("error", (e) => {
+            disconnectOnError();
+            reject(e);
+        });
+
+        if (!amdModule.loaded) {
+            loadModule(amdModule);
+        }
+    });
+}
+
+
+export function updateModuleGetter<K extends keyof IModuleGetter>(key: K, value: IModuleGetter[K]): void {
+    ModuleGetter[key] = value;
+}
+
+
+export async function loadModule(amdModule: IAmdModule): Promise<void> {
+    const modulePath = ModuleGetter.getModulePath(amdModule.name);
+    amdModule.path = modulePath;
+
+    const moduleContents = await ModuleGetter.getModuleContents(modulePath);
+
+    // Kick off the Module Load - 
+    const disconnectModuleDefined = amdModule.on("defined", (definedModule) => {
+        disconnectModuleDefined();
+        definedModule.load();
+    });
+
+    // wrap contents
+    const wrappedContents =
+    `(function (andModule, modulePath) {
+        
+        if (typeof define === "undefined") {
+            var define = andModule.defineModule;
+        }
+
+        ${moduleContents}
+    })`;
+
+    // Execute code
+    const compiledWrapper = vm.runInThisContext(wrappedContents, {
+        displayErrors: true,
+    });
+    compiledWrapper.apply(global, [exports]);
+}
+
+
+// Module is defined -> publish defined event
+export function defineModule(moduleId: string, dependencies: string[], factory: Function) {
+
+    let amdModule = ModuleCache[moduleId];
+    if (!amdModule) {
+        amdModule = new AmdModule(moduleId);
+        ModuleCache[moduleId] = amdModule;
+        amdModule.path = ModuleGetter.getModulePath(moduleId);
+    }
+
+    amdModule.dependencies = dependencies;
+    amdModule.factory = factory;
+
+
+    amdModule.emit("defined");
+}
+
+export class AmdModule implements IAmdModule {
+    public name: string;
+    public path: string;
+    public dependencies: string[];
+    public factory: Function;
+    public loaded: boolean;
+    public exports: any;
+
+    private _event: events.EventEmitter;
+    private _defined: boolean;
+    private _moduleLoader: Promise<this> | undefined;
+
+    constructor(name: string) {
+        this.name = name;
+        this.path = "";
+        this.dependencies = [];
+        this.factory = () => new Error(`no factory`);
+        this.loaded = false;
+
+        this._defined = false;
+        this._event = new events.EventEmitter();
+        this._moduleLoader = undefined;
+    }
+
+    public on(evtId: "defined" | "ready", callback: AmdModuleListener): EventDisconnect;
+    public on(evtId: "error", callback: (e: Error) => void): EventDisconnect;
+    public on(evtId: any, callback: any) {
+
+        let eventEmitter: events.EventEmitter | undefined;
+        if (evtId === "defined") {
+            if (this._defined) {
+                callback(this);
+            } else {
+                eventEmitter = this._event.on("defined", callback);
+            }
+        } else if (evtId === "ready") {
+            if (this.loaded) {
+                callback(this);
+            } else {
+                eventEmitter = this._event.on("ready", callback);
+            }
+        } else if (evtId === "error") {
+            eventEmitter = this._event.on("error", callback);
+        }
+
+        return eventEmitter ? () => { this._event.off(evtId, callback); } : () => {};
+    }
+
+    public emit(evtId: "defined" | "ready"): boolean {
+
+        let retValue: boolean = false;
+        if (evtId === "defined") {
+            this._defined = true;
+            retValue = this._event.emit(evtId, this);
+        } else if (evtId === "ready") {
+            this.loaded = true;
+            retValue = this._event.emit(evtId, this);
+        }
+
+        return retValue;
+    }
+
+    public async load(): Promise<this> {
+        if (!this._moduleLoader) {
+            this._moduleLoader = this._loadModule();
+        }
+
+        return this._moduleLoader;
+    }
+
+    private async _loadModule(): Promise<this> {
+        if (!this._defined) {
+            throw new Error(`AMD Module ${this.name} has not been defined`);
+        } else {
+
+            const dependenciesToLoad = this.dependencies
+            .filter(id => !ModuleCache[id])
+            .map(depModule => requireModule(depModule));
+
+            await Promise.all(dependenciesToLoad);
+            const dependencies = this.dependencies.map(id => ModuleCache[id].exports);
+
+            this.exports = this.factory.apply(global, dependencies);
+            this.emit("ready");
+            return this;
+        }
+    }
+}
+
+// Set global define function
+// tslint:disable-next-line: no-string-literal
+global["define"] = (moduleID: string, dependencies: string[], factory: Function) => {
+    defineModule(moduleID, dependencies, factory);
+};

--- a/src/requireJS-types.ts
+++ b/src/requireJS-types.ts
@@ -1,0 +1,45 @@
+
+export interface IObjectCollection<T> {
+    [key: string]: T;
+}
+
+export type Paths = IObjectCollection<string>;
+
+export type Bundles = IObjectCollection<string>;
+
+export type Shim = IObjectCollection<IShim>;
+
+export type ModuleMap = IObjectCollection<string>;
+
+export type ModuleConfig = IObjectCollection<IModuleConfig>;
+
+export type ModuleCallbackFunction = (...args: any[]) => any;
+
+export interface IShim {
+
+    deps?: string[];
+
+    exports?: string | ModuleCallbackFunction;
+
+    init?: ModuleCallbackFunction;
+}
+
+export interface IModuleConfig {
+    [key: string]: any;
+}
+
+export interface IRequireConfig {
+    baseUrl?: string;
+
+    paths?: Paths;
+
+    waitSeconds?: number;
+
+    bundles?: Bundles;
+
+    shim?: Shim;
+
+    map?: ModuleMap;
+
+    config?: ModuleConfig;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,13 +21,13 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "strict": false,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
Extremely crude implementation of loading AMD modules in node.
Based a little on require.js

Require will get the path and subsequently run the contents of the the file in a the nodes current context where the module can the be told to load its dependencies.
