### PR TITLE
Extract out AMD loader from AMD Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 **/*.d.ts
 **/*.js.map
 
+# Ignore Jest Coverage Folder
+coverage/
+
 # Track Jest config
 !/jest.config.js
 

--- a/__tests__/dummy.tests.ts
+++ b/__tests__/dummy.tests.ts
@@ -1,8 +1,0 @@
-describe(`Dummy Tests`, () => {
-
-    // Adding Fake test to pass travisCI build
-    it(`Fake tests`, () => {
-        const test = "fake";
-        expect(test).toBe("fake");
-    });
-});

--- a/__tests__/modules/amdModule.tests.ts
+++ b/__tests__/modules/amdModule.tests.ts
@@ -35,12 +35,6 @@ describe(`AMD Module Tests`, () => {
         expect(AmdModule.ModuleCache[moduleName]).toBeTruthy();
     });
 
-    it(`Verify that global define exists`, () => {
-        // tslint:disable-next-line: no-string-literal
-        const defineType = typeof global["define"];
-        expect(defineType).toBe("function");
-    });
-
     it(`Get Simple Module`, async () => {
         const moduleName = `simpleModules/moduleA`;
         const expectedModulePath = path.resolve(testDir, moduleName + ".js");
@@ -59,5 +53,85 @@ describe(`AMD Module Tests`, () => {
         expect(moduleA.exports.moduleName).toBe("moduleA");
     });
 
-});
+    it(`Load Module that depends on another - 1 dependency`, async() => {
+        const moduleName = `simpleModules/moduleB`;
+        const expectedModulePath = path.resolve(testDir, moduleName + ".js");
 
+        AmdModule.updateModuleGetter("getModulePath", (moduleName) => {
+            return path.resolve(testDir, moduleName + ".js");
+        });
+
+        AmdModule.updateModuleGetter("getModuleContents", (modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(AmdModule.ModuleCache[`simpleModules/moduleA`]).toBeFalsy();
+        expect(AmdModule.ModuleCache[`simpleModules/moduleB`]).toBeFalsy();
+
+        const moduleB = await AmdModule.requireModule(moduleName);
+        expect(moduleB).toBeTruthy();
+        expect(moduleB.path).toBe(expectedModulePath);
+        expect(moduleB.exports.moduleName).toBe("moduleB");
+
+        // Dependency cloned as a prop on it
+        expect(moduleB.exports.dependency.moduleName).toBe("moduleA");
+        expect(AmdModule.ModuleCache[moduleB.dependencies[0]]).toBeTruthy();
+    });
+
+    it(`Concatenated Modules moduleA`, async () => {
+        const moduleName = `complicatedModules/concatModulesA/moduleA`;
+        const expectedModulePath = path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+
+        AmdModule.updateModuleGetter("getModulePath", (moduleName) => {
+            return path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+        });
+
+        AmdModule.updateModuleGetter("getModuleContents", (modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleA`]).toBeFalsy();
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleB`]).toBeFalsy();
+
+        const moduleA = await AmdModule.requireModule(moduleName);
+        expect(moduleA).toBeTruthy();
+        expect(moduleA.path).toBe(expectedModulePath);
+        expect(moduleA.exports.moduleName).toBe("moduleA");
+
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleA`]).toBeTruthy();
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleB`]).toBeTruthy();
+
+        const moduleB = AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleB`];
+        expect(moduleB.loaded).toBeFalsy();
+    });
+
+    it(`Concatenated Module that depends on another - 1`, async () => {
+        const moduleName = `complicatedModules/concatModulesA/moduleB`;
+        const expectedModulePath = path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+
+        AmdModule.updateModuleGetter("getModulePath", (moduleName) => {
+            return path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+        });
+
+        AmdModule.updateModuleGetter("getModuleContents", (modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleA`]).toBeFalsy();
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleB`]).toBeFalsy();
+
+        const moduleB = await AmdModule.requireModule(moduleName);
+        expect(moduleB).toBeTruthy();
+        expect(moduleB.path).toBe(expectedModulePath);
+        expect(moduleB.exports.moduleName).toBe("moduleB");
+
+        // Dependency cloned as a prop on it
+        expect(moduleB.exports.dependency.moduleName).toBe("moduleA");
+
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleA`]).toBeTruthy();
+        expect(AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleB`]).toBeTruthy();
+
+        const moduleA = AmdModule.ModuleCache[`complicatedModules/concatModulesA/moduleA`];
+        expect(moduleA.loaded).toBeTruthy();
+    });
+});

--- a/__tests__/modules/amdModule.tests.ts
+++ b/__tests__/modules/amdModule.tests.ts
@@ -1,7 +1,7 @@
-import * as AmdModule from "../../src//modules/amdModule";
 import fs from "fs";
-import path, { dirname } from "path";
+import path from "path";
 import util from "util";
+import * as AmdModule from "../../src//modules/amdModule";
 
 const readFile = util.promisify(fs.readFile);
 

--- a/__tests__/modules/amdModuleV2.tests.ts
+++ b/__tests__/modules/amdModuleV2.tests.ts
@@ -1,0 +1,179 @@
+import fs from "fs";
+import path from "path";
+import util from "util";
+import * as amdLoader from "../../src/loader/amdLoader";
+import { IAmdModule } from "../../src/types/amdModuleTypes";
+
+const readFile = util.promisify(fs.readFile);
+
+describe(`AMD Module V2 Tests`, () => {
+    const testDir = ((): string => {
+        if (__dirname.match(/modules$/)) {
+            return path.resolve(__dirname, "../testData");
+        } else if (__dirname.match(/amd_loader$/)) {
+            return path.resolve(__dirname, "__tests__/testData");
+        } else {
+            return __dirname;
+        }
+    })();
+
+    beforeEach(() => {
+        amdLoader.moduleCache.clear();
+
+        amdLoader.loaderConfig.update({
+            moduleAccessor: {
+                getPathForModule: (moduleId: string) => {
+                    throw new Error(`getPathForModule not mocked ${moduleId}`);
+                },
+
+                getPathForModuleSync: (moduleId: string) => {
+                    throw new Error(`getPathForModuleSync not mocked ${moduleId}`);
+                },
+
+                getContentForModule: (moduleId: string, modulePath: string) => {
+                    throw new Error(`getContentForModule not mocked`);
+                },
+
+                isAmdModule: (moduleId: string) => {
+                    throw new Error(`isAmdModule not mocked`);
+                },
+            },
+        });
+    });
+
+    it(`Verify that normal Define Registers a module`, () => {
+        const moduleName = `simpleModules/moduleA`;
+        expect(amdLoader.getModuleFromCache(moduleName)).toBeFalsy();
+
+        amdLoader.loaderConfig.update("moduleAccessor", "getPathForModuleSync", (moduleId: string) => {
+            return moduleId;
+        });
+
+        amdLoader.defineModule(moduleName, [], () => "fsfsd");
+        expect(amdLoader.getModuleFromCache(moduleName)).toBeTruthy();
+    });
+
+    it(`Get Simple Module`, async () => {
+        const moduleName = `simpleModules/moduleA`;
+        const expectedModulePath = path.resolve(testDir, moduleName + ".js");
+
+        const getModulePath = (moduleId: string) => {
+            return path.resolve(testDir, moduleId + ".js");
+        };
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModule", moduleId => {
+            return Promise.resolve(getModulePath(moduleId));
+        });
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModuleSync", getModulePath);
+
+        amdLoader.loaderConfig.updateModuleAccessor("getContentForModule", (moduleId, modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        const moduleA = await amdLoader.requireModule(moduleName);
+        expect(moduleA).toBeTruthy();
+        expect(moduleA.path).toBe(expectedModulePath);
+        expect(moduleA.exports.moduleName).toBe("moduleA");
+    });
+
+    it(`Load Module that depends on another - 1 dependency`, async () => {
+        const moduleName = `simpleModules/moduleB`;
+        const expectedModulePath = path.resolve(testDir, moduleName + ".js");
+
+        const getModulePath = (moduleId: string) => {
+            return path.resolve(testDir, moduleId + ".js");
+        };
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModule", moduleId => {
+            return Promise.resolve(getModulePath(moduleId));
+        });
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModuleSync", getModulePath);
+
+        amdLoader.loaderConfig.updateModuleAccessor("getContentForModule", (moduleId, modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(amdLoader.getModuleFromCache(`simpleModules/moduleA`)).toBeFalsy();
+        expect(amdLoader.getModuleFromCache(`simpleModules/moduleB`)).toBeFalsy();
+
+        const moduleB = await amdLoader.requireModule(moduleName);
+        expect(moduleB).toBeTruthy();
+        expect(moduleB.path).toBe(expectedModulePath);
+        expect(moduleB.exports.moduleName).toBe("moduleB");
+
+        // Dependency cloned as a prop on it
+        expect(moduleB.exports.dependency.moduleName).toBe("moduleA");
+        expect(amdLoader.getModuleFromCache(moduleB.dependencies[0])).toBeTruthy();
+    });
+
+    it(`Concatenated Modules moduleA`, async () => {
+        const moduleName = `complicatedModules/concatModulesA/moduleA`;
+        const expectedModulePath = path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+
+        const getModulePath = (moduleId: string) => {
+            return path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+        };
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModule", moduleId => {
+            return Promise.resolve(getModulePath(moduleId));
+        });
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModuleSync", getModulePath);
+
+        amdLoader.loaderConfig.updateModuleAccessor("getContentForModule", (moduleId, modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleA`)).toBeFalsy();
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleB`)).toBeFalsy();
+
+        const moduleA = await amdLoader.requireModule(moduleName);
+        expect(moduleA).toBeTruthy();
+        expect(moduleA.path).toBe(expectedModulePath);
+        expect(moduleA.exports.moduleName).toBe("moduleA");
+
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleA`)).toBeTruthy();
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleB`)).toBeTruthy();
+
+        const moduleB = amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleB`) as IAmdModule;
+        expect(moduleB.loaded).toBeFalsy();
+    });
+
+    it(`Concatenated Module that depends on another - 1`, async () => {
+        const moduleName = `complicatedModules/concatModulesA/moduleB`;
+        const expectedModulePath = path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+
+        const getModulePath = (moduleId: string) => {
+            return path.resolve(testDir, `complicatedModules/concatModulesA` + ".js");
+        };
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModule", moduleId => {
+            return Promise.resolve(getModulePath(moduleId));
+        });
+
+        amdLoader.loaderConfig.updateModuleAccessor("getPathForModuleSync", getModulePath);
+
+        amdLoader.loaderConfig.updateModuleAccessor("getContentForModule", (moduleId, modulePath) => {
+            return readFile(modulePath, "utf8");
+        });
+
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleA`)).toBeFalsy();
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleB`)).toBeFalsy();
+
+        const moduleB = await amdLoader.requireModule(moduleName);
+        expect(moduleB).toBeTruthy();
+        expect(moduleB.path).toBe(expectedModulePath);
+        expect(moduleB.exports.moduleName).toBe("moduleB");
+
+        // Dependency cloned as a prop on it
+        expect(moduleB.exports.dependency.moduleName).toBe("moduleA");
+
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleA`)).toBeTruthy();
+        expect(amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleB`)).toBeTruthy();
+
+        const moduleA = amdLoader.moduleCache.get(`complicatedModules/concatModulesA/moduleA`) as IAmdModule;
+        expect(moduleA.loaded).toBeTruthy();
+    });
+});

--- a/__tests__/testData/complicatedModules/concatModulesA.js
+++ b/__tests__/testData/complicatedModules/concatModulesA.js
@@ -1,0 +1,11 @@
+define("complicatedModules/concatModulesA/moduleA", [], function() {
+    return {
+        moduleName: "moduleA"
+    }
+});
+define("complicatedModules/concatModulesA/moduleB", ["complicatedModules/concatModulesA/moduleA"], function(moduleA) {
+    return {
+        moduleName: "moduleB",
+        dependency: moduleA
+    }
+});

--- a/__tests__/testData/simpleModules/moduleB.js
+++ b/__tests__/testData/simpleModules/moduleB.js
@@ -1,0 +1,7 @@
+
+define("simpleModules/moduleB", ["simpleModules/moduleA"], function(moduleA) {
+    return {
+        moduleName: "moduleB",
+        dependency: moduleA
+    }
+});

--- a/__tests__/utils/configWrapper.tests.ts
+++ b/__tests__/utils/configWrapper.tests.ts
@@ -1,0 +1,92 @@
+import { ConfigWrapper } from "../../src/utils/configWrapper";
+
+describe(`ConfigWrapper Tests`, () => {
+
+    it(`Simple Object Type - Access Values`, () => {
+
+        const initialObject = {
+            name: `TestX`,
+            items: []
+        };
+
+        const wrapper = new ConfigWrapper(initialObject);
+        expect(wrapper.getValue("name")).toBe(initialObject.name);
+
+        const items = wrapper.getValue("items");
+        expect(items).toBeTruthy();
+        if (items) {
+            expect(items.length).toBe(initialObject.items.length);
+        }
+    });
+
+    it(`Simple Object type - Update Values Key,Value`, () => {
+        const initialObject = {
+            name: `TestX`,
+            items: []
+        };
+
+        const wrapper = new ConfigWrapper(initialObject);
+
+        wrapper.updateValue("name", "updated");
+        expect(wrapper.getValue("name")).toBe("updated");
+    });
+
+    it(`Simple Object type - Update Values single tuple`, () => {
+        const initialObject = {
+            name: `TestX`,
+            items: [5],
+        };
+
+        const wrapper = new ConfigWrapper(initialObject);
+
+        wrapper.updateValue(["items", [4, 4]]);
+        const items = wrapper.getValue("items");
+
+        expect(items).toBeTruthy();
+        if (items) {
+            expect(items.length).toBe(2);1
+        }
+    });
+
+    it(`Simple Object type - Update Values multiple tuple`, () => {
+        const initialObject = {
+            name: `TestX`,
+            items: [5],
+        };
+
+        const wrapper = new ConfigWrapper(initialObject);
+
+        wrapper.updateValue([
+            ["items", [4, 4]],
+            ["name", "magic"],
+        ]);
+
+        expect(wrapper.getValue("name")).toBe("magic");
+        const items = wrapper.getValue("items");
+        expect(items).toBeTruthy();
+        if (items) {
+            expect(items.length).toBe(2);
+        }
+    });
+
+    it(`Simple Object type - Update object`, () => {
+        const initialObject = {
+            name: `TestX`,
+            items: [5],
+        };
+
+        const wrapper = new ConfigWrapper(initialObject);
+        wrapper.updateValue({
+            name: "0101",
+            items: [],
+        });
+
+        expect(wrapper.getValue("name")).toBe("0101");
+
+        const items = wrapper.getValue("items");
+        expect(items).toBeTruthy();
+        if (items) {
+            expect(items.length).toBeFalsy();
+        }
+    });
+});

--- a/src/loader/amdLoader.ts
+++ b/src/loader/amdLoader.ts
@@ -9,5 +9,5 @@ export const LoaderConfig: ConfigWrapper<IAmdLoaderConfig> = new ConfigWrapper()
 
 
 export function requireModule(moduleId: string): Promise<IAmdModule> {
-
+    throw new Error("not implemented");
 }

--- a/src/loader/amdLoader.ts
+++ b/src/loader/amdLoader.ts
@@ -1,13 +1,161 @@
-import { IAmdLoaderConfig } from "../types/amdLoaderTypes";
+import vm from "vm";
+import { AmdModuleV2 } from "../modules/amdModuleV2";
 import { IAmdModule } from "../types/amdModuleTypes";
-import { RequireModule } from "../types/amdModuleTypes";
-import { ConfigWrapper } from "../utils/configWrapper";
+import { FactoryFn } from "../types/amdModuleTypes";
+import { AmdLoaderConfig } from "./amdLoaderConfig";
 
-export const ModuleCache: Map<string, IAmdModule> = new Map();
+/**
+ * Cache of currently Defined/Loaded AMD Modules
+ */
+export const moduleCache: Map<string, IAmdModule> = new Map();
 
-export const LoaderConfig: ConfigWrapper<IAmdLoaderConfig> = new ConfigWrapper();
+/**
+ * AMD Loader Configuration instance
+ */
+export const loaderConfig: AmdLoaderConfig = new AmdLoaderConfig();
 
-
+/**
+ * Asysnnchronously load an AMD module for the supplied module ID.
+ * If the module has not allready been registered, it will be created
+ * and the load process will happen immediatly.
+ *
+ * Any dependent modules will be loadeded as well.
+ * If a concatenated module file is loaded during the process all if its
+ * module definitions will be registered in the module cache, but they will not be
+ * loaded till they are needed
+ * @param {strng} moduleId - Module to be loaded
+ */
 export function requireModule(moduleId: string): Promise<IAmdModule> {
-    throw new Error("not implemented");
+    return new Promise<IAmdModule>((resolve, reject) => {
+
+        let amdModule = getModuleFromCache(moduleId);
+        if (!amdModule) {
+            amdModule = createModule(moduleId);
+            moduleCache.set(moduleId, amdModule);
+        }
+
+        if (amdModule.loaded) {
+            resolve(amdModule);
+            return amdModule;
+        }
+
+        const disconnectOnReady = amdModule.on("ready", (loadedModule) => {
+            disconnectOnReady();
+            resolve(loadedModule);
+        });
+
+        const disconnectOnError = amdModule.on("error", (e) => {
+            disconnectOnError();
+            reject(e);
+        });
+
+        if (!amdModule.loaded) {
+            loadModule(amdModule);
+        }
+    });
+}
+
+/**
+ * Load a AMD module by first
+ * getting the contents of file and wrapping the contents
+ * in a module function to inject the 'define' function.
+ *
+ * This will cause the AMD module to then invoke the define function
+ * completing the initial registration. Once the module has been 'defined'
+ *
+ * The module will then be loaded, causing any of its dependencies to be loaded.
+ * @param {IAmdModule} amdModule - AMD Module that is to be loaded.
+ * This can be created via the require or during a concatenated module load
+ * 
+ */
+export async function loadModule(amdModule: IAmdModule): Promise<void> {
+    const modulePath = await loaderConfig.moduleAccessor.getPathForModule(amdModule.name);
+    amdModule.path = modulePath;
+
+    const moduleContents = await loaderConfig.moduleAccessor.getContentForModule(amdModule.name, modulePath);
+
+    // Kick off the Module Load - 
+    const disconnectModuleDefined = amdModule.on("defined", (definedModule) => {
+        disconnectModuleDefined();
+        definedModule.load();
+    });
+
+    compileAndExecuteModuleCode(moduleContents);
+}
+
+/**
+ * Wrap the supplied module code in a function
+ * that will supply the 'define' module definition function
+ * to enable the AMD modules to be registered into the module cache.
+ * In addition the supplied factory function will stored and associed with
+ * the module.
+ * 
+ * Note - this will execute the code in 'this' context
+ */
+export function compileAndExecuteModuleCode(rawMouldeCode: string): void {
+    // wrap contents
+    const wrappedContents =
+        `(function (andModule, modulePath) {
+            if (typeof define === "undefined") {
+                var define = andModule.defineModule;
+            }
+            ${rawMouldeCode}
+        })`;
+
+    // Compile the code
+    const compiledWrapper = vm.runInThisContext(wrappedContents, {
+        displayErrors: true,
+    });
+
+    // Execute the code, sending in 'this' as dependency to wrapper function
+    compiledWrapper.apply(global, [exports]);
+}
+
+/**
+ * Define a AMD Module.
+ * This registers the module Id with its dependencies and factory method
+ * enabling the full 'load' of the module to be performed later.
+ * 
+ * Note - this function will be invoked during a module 'load' IE
+ * when require loads and executes the file.
+ * @param {string} moduleId - Module Id that this definition will be registered as
+ * @param {string[]} dependencies - Array of module ids that are required to be loaded and 
+ * passed into the factory function
+ * @param {function} factory - Factory function that takes dependencies to execute the actual
+ * 'module' code. The result of which will be stored on the modules exports. 
+ */
+export function defineModule(moduleId: string, dependencies: string[], factory: FactoryFn) {
+
+    let amdModule = getModuleFromCache(moduleId);
+    if (!amdModule) {
+        amdModule = createModule(moduleId);
+        moduleCache.set(moduleId, amdModule);
+        amdModule.path = loaderConfig.moduleAccessor.getPathForModuleSync(moduleId);
+    }
+
+    amdModule.dependencies = dependencies;
+    amdModule.factory = factory;
+
+    amdModule.emit("defined");
+}
+
+/**
+ * Create a new AMD Module injecting the 'require' and 'getModule' functions
+ * from the loader
+ * @param {string} moduleId - id/name of the module
+ */
+export function createModule(moduleId: string): IAmdModule {
+    return new AmdModuleV2({
+        name: moduleId,
+        requireModule,
+        getModuleFromCache,
+    });
+}
+
+/**
+ * Function wrapper to get a specified module from the cache
+ * @param {string} id - Module Id
+ */
+export function getModuleFromCache(id: string): IAmdModule | undefined {
+    return moduleCache.get(id);
 }

--- a/src/loader/amdLoader.ts
+++ b/src/loader/amdLoader.ts
@@ -1,0 +1,13 @@
+import { IAmdLoaderConfig } from "../types/amdLoaderTypes";
+import { IAmdModule } from "../types/amdModuleTypes";
+import { RequireModule } from "../types/amdModuleTypes";
+import { ConfigWrapper } from "../utils/configWrapper";
+
+export const ModuleCache: Map<string, IAmdModule> = new Map();
+
+export const LoaderConfig: ConfigWrapper<IAmdLoaderConfig> = new ConfigWrapper();
+
+
+export function requireModule(moduleId: string): Promise<IAmdModule> {
+
+}

--- a/src/loader/amdLoaderConfig.ts
+++ b/src/loader/amdLoaderConfig.ts
@@ -1,0 +1,27 @@
+import { IModuleAccessorConfig } from "../types/amdLoaderTypes";
+import { IAmdLoaderConfig } from "../types/amdLoaderTypes";
+import { ConfigWrapper } from "../utils/configWrapper";
+
+export class AmdLoaderConfig implements IAmdLoaderConfig {
+    private _config: ConfigWrapper<IAmdLoaderConfig>;
+
+    constructor() {
+        this._config = new ConfigWrapper();
+    }
+
+    public get moduleAccessor(): IModuleAccessorConfig {
+        const accessor = this._config.getValue("moduleAccessor");
+        if (!accessor) {
+            throw new Error(`Module Accessor has not been set`);
+        }
+        return accessor;
+    }
+
+    public get update() {
+        return this._config.updateValue.bind(this._config);
+    }
+
+    public updateModuleAccessor<K extends keyof IModuleAccessorConfig>(prop: K, value: IModuleAccessorConfig[K]) {
+        this.update("moduleAccessor", prop, value);
+    }
+}

--- a/src/modules/amdModule.ts
+++ b/src/modules/amdModule.ts
@@ -1,25 +1,10 @@
 
 import events from "events";
 import vm from "vm";
-
-export type AmdModuleListener = (amdModule: IAmdModule) => void;
-export type EventDisconnect = () => void;
-
-export interface IAmdModule {
-    name: string;
-    path: string;
-    dependencies: string[];
-    factory: Function;
-    loaded: boolean;
-    exports: any;
-
-    on(evtId: "defined" | "ready", callback: AmdModuleListener): EventDisconnect;
-    on(evtId: "error", callback: (e: Error) => void ): EventDisconnect;
-
-    emit(evtId: "defined" | "ready"): boolean;
-
-    load(): Promise<this>;
-}
+import { IAmdModule } from "../types/amdModuleTypes";
+import { FactoryFn } from "../types/amdModuleTypes";
+import { GenericFunction0 } from "../types/commonTypes";
+import { GenericFunction1 } from "../types/commonTypes";
 
 /**
  * Helper object to assist with 
@@ -155,7 +140,7 @@ export async function loadModule(amdModule: IAmdModule): Promise<void> {
  * @param {function} factory - Factory function that takes dependencies to execute the actual
  * 'module' code. The result of which will be stored on the modules exports. 
  */
-export function defineModule(moduleId: string, dependencies: string[], factory: Function) {
+export function defineModule(moduleId: string, dependencies: string[], factory: FactoryFn) {
 
     let amdModule = ModuleCache[moduleId];
     if (!amdModule) {
@@ -174,7 +159,7 @@ export class AmdModule implements IAmdModule {
     public name: string;
     public path: string;
     public dependencies: string[];
-    public factory: Function;
+    public factory: FactoryFn;
     public loaded: boolean;
     public exports: any;
 
@@ -194,8 +179,8 @@ export class AmdModule implements IAmdModule {
         this._moduleLoader = undefined;
     }
 
-    public on(evtId: "defined" | "ready", callback: AmdModuleListener): EventDisconnect;
-    public on(evtId: "error", callback: (e: Error) => void): EventDisconnect;
+    public on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;
+    public on(evtId: "error", callback: (e: Error) => void): GenericFunction0;
     public on(evtId: any, callback: any) {
 
         let eventEmitter: events.EventEmitter | undefined;

--- a/src/modules/amdModule.ts
+++ b/src/modules/amdModule.ts
@@ -1,6 +1,7 @@
 
 import events from "events";
 import vm from "vm";
+import { RequireModule } from "../types/amdModuleTypes";
 import { IAmdModule } from "../types/amdModuleTypes";
 import { FactoryFn } from "../types/amdModuleTypes";
 import { GenericFunction0 } from "../types/commonTypes";
@@ -58,7 +59,7 @@ export function requireModule(moduleId: string): Promise<IAmdModule> {
 
         let amdModule = ModuleCache[moduleId];
         if (!amdModule) {
-            amdModule = new AmdModule(moduleId);
+            amdModule = new AmdModule(moduleId, requireModule);
             ModuleCache[moduleId] = amdModule;
         }
 
@@ -144,7 +145,7 @@ export function defineModule(moduleId: string, dependencies: string[], factory: 
 
     let amdModule = ModuleCache[moduleId];
     if (!amdModule) {
-        amdModule = new AmdModule(moduleId);
+        amdModule = new AmdModule(moduleId, requireModule);
         ModuleCache[moduleId] = amdModule;
         amdModule.path = ModuleGetter.getModulePath(moduleId);
     }
@@ -162,12 +163,13 @@ export class AmdModule implements IAmdModule {
     public factory: FactoryFn;
     public loaded: boolean;
     public exports: any;
+    public requireModule: RequireModule;
 
     private _event: events.EventEmitter;
     private _defined: boolean;
     private _moduleLoader: Promise<this> | undefined;
 
-    constructor(name: string) {
+    constructor(name: string, requireModule: RequireModule) {
         this.name = name;
         this.path = "";
         this.dependencies = [];
@@ -177,6 +179,7 @@ export class AmdModule implements IAmdModule {
         this._defined = false;
         this._event = new events.EventEmitter();
         this._moduleLoader = undefined;
+        this.requireModule = requireModule;
     }
 
     public on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;

--- a/src/modules/amdModuleV2.ts
+++ b/src/modules/amdModuleV2.ts
@@ -1,0 +1,139 @@
+import { EventEmitter } from "events";
+import { IAmdModuleConfig } from "../types/amdModuleTypes";
+import { IAmdModuleV2 } from "../types/amdModuleTypes";
+import { IAmdModule } from "../types/amdModuleTypes";
+import { FactoryFn } from "../types/amdModuleTypes";
+import { RequireModule } from "../types/amdModuleTypes";
+import { GenericFunction1 } from "../types/commonTypes";
+import { GenericFunction0 } from "../types/commonTypes";
+
+export class AmdModuleV2 implements IAmdModuleV2 {
+    public name: string;
+    public path: string;
+    public dependencies: string[];
+    public factory: FactoryFn;
+    public loaded: boolean;
+    public exports: any;
+    public requireModule: RequireModule;
+
+    /**
+     * Event Emitter
+     */
+    private _event: EventEmitter;
+
+    /**
+     * Has this module been defined
+     */
+    private _defined: boolean;
+
+    private _moduleLoader: Promise<this> | undefined;
+
+    private _getModuleFromCache: (id: string) => IAmdModule | undefined;
+
+    constructor(config: IAmdModuleConfig) {
+        this._event = new EventEmitter();
+        this._defined = false;
+        this._moduleLoader = undefined;
+
+        this.name = config.name;
+        this.path = config.path || "";
+        this.dependencies = config.dependencies || [];
+        this.factory = config.factory || (() => {
+            const error = new Error(`Factory has not been supplied`);
+            this._emitError(error);
+            throw(error);
+        });
+        this.loaded = !!config.loaded;
+        this.requireModule = config.requireModule;
+        this._getModuleFromCache = config.getModuleFromCache;
+    }
+
+    public on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;
+    public on(evtId: "error", callback: (e: Error) => void): GenericFunction0;
+    public on(evtId: any, callback: any) {
+
+        let eventEmitter: EventEmitter | undefined;
+        if (evtId === "defined" && !this._defined) {
+            eventEmitter = this._event.on("defined", callback);
+        } else if (evtId === "ready" && !this.loaded) {
+            eventEmitter = this._event.on("ready", callback);
+        } else if (evtId === "error") {
+            eventEmitter = this._event.on("error", callback);
+        }
+
+        // In the case that we don't have an event emitter
+        // trigger the callback on the next tick to keep this function 'async'
+        if (!eventEmitter) {
+            process.nextTick(() => {
+                callback(this);
+            });
+        }
+
+        return eventEmitter ? () => { this._event.off(evtId, callback); } : () => { };
+    }
+
+    public emit(evtId: "defined" | "ready"): boolean {
+
+        let retValue: boolean = false;
+        if (evtId === "defined") {
+            this._defined = true;
+            retValue = this._event.emit(evtId, this);
+        } else if (evtId === "ready") {
+            this.loaded = true;
+            retValue = this._event.emit(evtId, this);
+        }
+
+        return retValue;
+    }
+
+    public async load(): Promise<this> {
+        // cache the promise to ensure that the loading only occurs once
+        if (!this._moduleLoader) {
+            this._moduleLoader = this._loadModule();
+        }
+
+        return this._moduleLoader;
+    }
+
+    private async _loadModule(): Promise<this> {
+        if (!this._defined) {
+            throw new Error(`AMD Module ${this.name} has not been defined`);
+        } else {
+
+            // const moduleGetter = this.config.getValue("getModuleFromCache");
+            const dependenciesToLoad = (this.dependencies || [])
+                .filter(id => {
+                    const cachedModule = this._getModuleFromCache(id);
+                    return !cachedModule || !cachedModule.loaded;
+                })
+                .map(moduleIdToLoad => this.requireModule(moduleIdToLoad));
+
+            await Promise.all(dependenciesToLoad);
+
+            const dependencies = (this.dependencies || []).map(id => {
+                const loadedModule = this._getModuleFromCache(id);
+                if (!loadedModule) {
+                    const error = new Error(`Module Dependency ${id} was not loaded`);
+                    this._emitError(error);
+                    throw error;
+                } else {
+                    return loadedModule.exports;
+                }
+            });
+
+            if (!this.factory) {
+                const error = new Error(`Module Factory is not defined`);
+                this._emitError(error);
+                throw error;
+            }
+
+            this.exports = this.factory.apply(global, dependencies);
+            this.emit("ready");
+            return this;
+        }
+    }
+
+    private _emitError(e: Error): void {
+        this._event.emit("error", e);
+    }
+}

--- a/src/types/amdLoaderTypes.ts
+++ b/src/types/amdLoaderTypes.ts
@@ -1,0 +1,15 @@
+import { IAmdModule } from "./amdModuleTypes";
+
+export interface IAmdLoaderConfig {
+
+    moduleAccessor: IModuleAccessorConfig;
+}
+
+export interface IModuleAccessorConfig {
+
+    isAmdModule(moduleId: string): boolean;
+
+    getPathForModule(moduleId: string): Promise<string>;
+
+    getContentForModule(moduleId: string, modulePath: string): Promise<string>;
+}

--- a/src/types/amdLoaderTypes.ts
+++ b/src/types/amdLoaderTypes.ts
@@ -11,5 +11,7 @@ export interface IModuleAccessorConfig {
 
     getPathForModule(moduleId: string): Promise<string>;
 
+    getPathForModuleSync(moduleId: string): string;
+
     getContentForModule(moduleId: string, modulePath: string): Promise<string>;
 }

--- a/src/types/amdModuleTypes.ts
+++ b/src/types/amdModuleTypes.ts
@@ -1,0 +1,38 @@
+import { GenericFunction0 } from "./commonTypes";
+import { GenericFunction1 } from "./commonTypes";
+
+export type FactoryFn = (...deps: any[]) => any;
+
+export interface IAmdModuleConfig {
+    name?: string;
+    path?: string;
+    dependencies?: string[];
+    factory?: FactoryFn;
+    loaded?: boolean;
+    exports?: any;
+
+    requireModule?: RequireModule;
+}
+
+export interface IAmdModule {
+    name: string;
+    path: string;
+    dependencies: string[];
+    factory: FactoryFn;
+    loaded: boolean;
+    exports: any;
+
+    on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;
+    on(evtId: "error", callback: (e: Error) => void ): GenericFunction0;
+
+    emit(evtId: "defined" | "ready"): boolean;
+
+    load(): Promise<this>;
+}
+
+export type RequireModule = (moduleId: string) => Promise<IAmdModule>;
+
+export interface IRequireModule {
+    (moduleId: string): Promise<IAmdModule>;
+    (moduleId: string[]): Promise<IAmdModule[]>;
+}

--- a/src/types/amdModuleTypes.ts
+++ b/src/types/amdModuleTypes.ts
@@ -4,14 +4,16 @@ import { GenericFunction1 } from "./commonTypes";
 export type FactoryFn = (...deps: any[]) => any;
 
 export interface IAmdModuleConfig {
-    name?: string;
+    name: string;
     path?: string;
     dependencies?: string[];
     factory?: FactoryFn;
     loaded?: boolean;
     exports?: any;
 
-    requireModule?: RequireModule;
+    requireModule: RequireModule;
+
+    getModuleFromCache(moduleId: string): IAmdModule | undefined;
 }
 
 export interface IAmdModule {
@@ -21,9 +23,10 @@ export interface IAmdModule {
     factory: FactoryFn;
     loaded: boolean;
     exports: any;
+    requireModule: RequireModule;
 
     on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;
-    on(evtId: "error", callback: (e: Error) => void ): GenericFunction0;
+    on(evtId: "error", callback: (e: Error) => void): GenericFunction0;
 
     emit(evtId: "defined" | "ready"): boolean;
 
@@ -35,4 +38,21 @@ export type RequireModule = (moduleId: string) => Promise<IAmdModule>;
 export interface IRequireModule {
     (moduleId: string): Promise<IAmdModule>;
     (moduleId: string[]): Promise<IAmdModule[]>;
+}
+
+export interface IAmdModuleV2 {
+    name: string;
+    path: string;
+    dependencies: string[];
+    factory: FactoryFn;
+    loaded: boolean;
+    exports: any;
+    requireModule: RequireModule;
+
+    on(evtId: "defined" | "ready", callback: GenericFunction1<this>): GenericFunction0;
+    on(evtId: "error", callback: (e: Error) => void): GenericFunction0;
+
+    emit(evtId: "defined" | "ready"): boolean;
+
+    load(): Promise<this>;
 }

--- a/src/types/commonTypes.ts
+++ b/src/types/commonTypes.ts
@@ -1,0 +1,30 @@
+/**
+ * @module - Collection of common and generic types
+ */
+
+/**
+ * Generic object that represents a map
+ * that for every property will have 'T'
+ * value.
+ */
+export interface IObjectMap<T> {
+    [key: string]: T;
+}
+
+/**
+ * Generic function that that has zero
+ * parameters
+ */
+export type GenericFunction0 = () => void;
+
+/**
+ * Generic function that has one
+ * parameter
+ */
+export type GenericFunction1<P1> = (data: P1) => void;
+
+/**
+ * Generic function that takes two
+ * parameters
+ */
+export type GenericFunction2<P1, P2> = (p1: P1, p2: P2) => void;

--- a/src/utils/configWrapper.ts
+++ b/src/utils/configWrapper.ts
@@ -17,10 +17,12 @@ export class ConfigWrapper<T extends object> {
      * Get the value currently assigned to the given property
      * @param {K extends keyof T} prop - property key to get the value for
      */
-    public getValue<K extends keyof T>(prop: K): T[K] | undefined {
+    public getValue<K extends keyof T>(prop: K): T[K] {
         if (this.config) {
             return this.config[prop];
         }
+
+        throw new Error(`Config has not been set, unable to get value for ${prop}`);
     }
 
     /**
@@ -53,6 +55,14 @@ export class ConfigWrapper<T extends object> {
     public updateValue(value: T): this;
 
     /**
+     * Update a sub property on the config object
+     * @param {K1} key1 - Initial Property to targer
+     * @param {K2} key2 - Sub Property to change
+     * @param {T[K1][K2]} value - Value to assign to sub property
+     */
+    public updateValue<K1 extends keyof T, K2 extends keyof T[K1]>(key1: K1, key2: K2, value: T[K1][K2]): this;
+
+    /**
      * Update value implementation.
      * This will parse the arguments to determine the update 'mode'
      * If arg[0] is a string it assumed that we are updating a single key/value
@@ -80,6 +90,11 @@ export class ConfigWrapper<T extends object> {
                 return this;
             }
 
+            if (args.length > 2) {
+                this.config[args[0]][args[1]] = args[2];
+                return this;
+            }
+
             // update tuple mode
             let updatePairs: Array<[any, any]> = [];
 
@@ -99,6 +114,11 @@ export class ConfigWrapper<T extends object> {
             throw new Error(`Can not update config as it is undefined`);
         }
 
+        return this;
+    }
+
+    public clearConfig(): this {
+        this.config = undefined;
         return this;
     }
 }

--- a/src/utils/configWrapper.ts
+++ b/src/utils/configWrapper.ts
@@ -1,0 +1,104 @@
+
+/**
+ * Simple type denoting a key value pair that can
+ * be used to perform updates
+ */
+export type UpdateTuple<K, V> = [K, V];
+
+export class ConfigWrapper<T extends object> {
+
+    private config: T | undefined;
+
+    constructor(data?: T) {
+        this.config = data;
+    }
+
+    /**
+     * Get the value currently assigned to the given property
+     * @param {K extends keyof T} prop - property key to get the value for
+     */
+    public getValue<K extends keyof T>(prop: K): T[K] | undefined {
+        if (this.config) {
+            return this.config[prop];
+        }
+    }
+
+    /**
+     * Update the config with the supplied value
+     * @param {keyof T} prop - property to update
+     * @param {T[K]} value  - value to be assigned
+     */
+    public updateValue<K extends keyof T>(prop: K, value: T[K]): this;
+
+    /**
+     * Update the config given a single update tuple.
+     * 
+     * @param {UpdateTuple<K, T[K]>} values -
+     * values[0] is the property key
+     * values[1] is the value to assign to the property
+     * 
+     */
+    public updateValue<K extends keyof T>(values: UpdateTuple<K, T[K]>): this;
+
+    /**
+     * Update the config given a collection of update tuples
+     * @param {Array<UpdateTuple<K, T[K]>>} values - Array of update tuples
+     */
+    // tslint:disable-next-line: unified-signatures - it is clearly confused...
+    public updateValue<K extends keyof T>(values: Array<UpdateTuple<K, T[K]>>): this;
+
+    /**
+     * Update the config by replacing the current config object with the new one
+     */
+    public updateValue(value: T): this;
+
+    /**
+     * Update value implementation.
+     * This will parse the arguments to determine the update 'mode'
+     * If arg[0] is a string it assumed that we are updating a single key/value
+     * If arg[0] is a object we are replacing the current config with it
+     * If arg[0] is an array and its first element is not an array we are
+     * assuming its a single update tuple
+     * If arg[0] is an array and its first element is also an array assuming
+     * we have a collection of update tuples
+     * @param {any} args - arguments that will be used to control the config update
+     */
+    public updateValue(...args: any[]): this {
+
+        // Supplied a replacement object
+        if (args.length === 1 && !Array.isArray(args[0])) {
+            this.config = args[0];
+            return this;
+        }
+
+        // Need to have a config exist to update individual values
+        if (this.config) {
+
+            // Key, Value supplied in - assign and bail out
+            if (args.length === 2 && typeof args[0] === "string") {
+                this.config[args[0]] = args[1];
+                return this;
+            }
+
+            // update tuple mode
+            let updatePairs: Array<[any, any]> = [];
+
+            // Single Key, Value tuple
+            if (Array.isArray(args[0]) && !Array.isArray(args[0][0])) {
+                updatePairs.push(args[0]);
+            // Array of Update Tuples
+            } else if (Array.isArray(args[0]) && Array.isArray(args[0][0])) {
+                updatePairs = args[0].slice(0);
+            }
+
+            // loop through and apply the updates
+            for (const updateData of updatePairs) {
+                this.config[updateData[0]] = updateData[1];
+            }
+        } else {
+            throw new Error(`Can not update config as it is undefined`);
+        }
+
+        return this;
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,16 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+        "arrow-parens": [false, "ban-single-arg-parens"],
+        "object-literal-sort-keys": false,
+        "variable-name": {
+            "options": [
+                "allow-leading-underscore",
+                "check-format",
+                "ban-keywords"
+            ]
+        }
+    },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Rough work to separate the AMD loader logic from the AMD Module.

Small tweaks to make it easier to test
Started work on amdModuleV2 to replace existing amdModule